### PR TITLE
Switch Auth0 management to WebClient + WebFlux

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -32,6 +32,13 @@
 		<java.version>25</java.version>
 	</properties>
 	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+			<version>3.5.3</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/backend/src/main/java/com/smartcampus/backend/BackendApplication.java
+++ b/backend/src/main/java/com/smartcampus/backend/BackendApplication.java
@@ -22,4 +22,6 @@ public class BackendApplication {
 		String message = "This is a Health Check";
 		return message;
 	}
+
+	
 }

--- a/backend/src/main/java/com/smartcampus/backend/config/WebConfig.java
+++ b/backend/src/main/java/com/smartcampus/backend/config/WebConfig.java
@@ -1,18 +1,28 @@
 package com.smartcampus.backend.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
     @Override
-    public void addCorsMappings(CorsRegistry registry){
+    public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-            .allowedOrigins("http://localhost:3000")
-            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
-            .allowedHeaders("*")
-            .allowCredentials(true);
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder()
+                .codecs(config -> config.defaultCodecs()
+                        .maxInMemorySize(5 * 1024 * 1024))
+                .build();
     }
 
 }

--- a/backend/src/main/java/com/smartcampus/backend/controller/Auth0ManagementController.java
+++ b/backend/src/main/java/com/smartcampus/backend/controller/Auth0ManagementController.java
@@ -1,12 +1,12 @@
 package com.smartcampus.backend.controller;
 
 import java.net.URLEncoder;
+import org.springframework.http.HttpHeaders;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -17,7 +17,10 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import com.smartcampus.backend.config.Auth0ManagementProperties;
 import com.smartcampus.backend.dto.ApiResponse;
@@ -28,10 +31,14 @@ import com.smartcampus.backend.dto.auth0.Auth0UserResponse;
 import com.smartcampus.backend.service.Auth0ManagementApiService;
 import com.smartcampus.backend.service.Auth0ManagementTokenService;
 
+import jakarta.servlet.http.HttpServletRequest;
+import reactor.core.publisher.Mono;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.PostMapping;
 
@@ -43,10 +50,13 @@ public class Auth0ManagementController {
         private final RestClient restClient;
         private final Auth0ManagementProperties props;
         private final Auth0ManagementTokenService tokenService;
+        private final WebClient webClient;
 
-        public Auth0ManagementController(Auth0ManagementProperties props, Auth0ManagementTokenService tokenService) {
+        public Auth0ManagementController(Auth0ManagementProperties props, Auth0ManagementTokenService tokenService,
+                        WebClient webClient) {
                 this.props = props;
                 this.tokenService = tokenService;
+                this.webClient = webClient;
                 this.restClient = RestClient.builder().baseUrl(props.apiBaseUrl()).build();
         }
 
@@ -87,72 +97,239 @@ public class Auth0ManagementController {
                                 .body(response);
         }
 
-        // create user
-        @PostMapping("/users")
-        public ResponseEntity<?> createUser(
-                        @RequestBody Object body, // Accepts any {} or []
-                        Authentication authentication) {
-                String token = tokenService.getAccessToken();
+        // ---------------------------------------------------------------------
 
-                return restClient.post()
-                                .uri(uriBuilder -> uriBuilder
-                                                .path("/users")
-                                                .build())
+        // create user
+        // @PostMapping("/users")
+        // public ResponseEntity<?> createUser(
+        // @RequestBody Object body, // Accepts any {} or []
+        // Authentication authentication) {
+        // String token = tokenService.getAccessToken();
+
+        // return restClient.post()
+        // .uri(uriBuilder -> uriBuilder
+        // .path("/users")
+        // .build())
+        // .header("Authorization", "Bearer " + token)
+        // .body(body)
+        // .retrieve()
+        // .onStatus(status -> !status.is2xxSuccessful(),
+        // (request, response) -> {
+        // byte[] body_bytes = response.getBody().readAllBytes();
+        // if (response.getStatusCode().is4xxClientError()) {
+        // throw new HttpClientErrorException(
+        // response.getStatusCode(),
+        // response.getStatusText(),
+        // response.getHeaders(), body_bytes,
+        // StandardCharsets.UTF_8);
+        // } else {
+        // throw new HttpServerErrorException(
+        // response.getStatusCode(),
+        // response.getStatusText(),
+        // response.getHeaders(), body_bytes,
+        // StandardCharsets.UTF_8);
+        // }
+        // })
+        // .toEntity(Object.class);
+        // }
+
+        @PostMapping("/users")
+        public Mono<ResponseEntity<String>> createUser(
+                        @RequestBody String body,
+                        Authentication authentication,
+                        HttpServletRequest request,
+                        @RequestHeader HttpHeaders headers) {
+                String token = tokenService.getAccessToken();
+                String url = props.apiBaseUrl() + "/users/";
+                return webClient.post()
+                                .uri(url)
                                 .header("Authorization", "Bearer " + token)
-                                .body(body)
-                                .retrieve()
-                                .toEntity(Object.class);
+                                .header("Content-Type", "application/json")
+                                .bodyValue(body)
+                                .exchangeToMono(response -> response.bodyToMono(String.class)
+                                                .defaultIfEmpty("")
+                                                .map(b -> ResponseEntity
+                                                                .status(response.statusCode())
+                                                                .body(b)));
         }
+
+        // ----------------------------------------------------------------------
 
         // delete user
-        @DeleteMapping("/users/{id}")
-        public ResponseEntity<?> deleteUsers(
-                        @PathVariable String id,
-                        Authentication authentication) {
-                String token = tokenService.getAccessToken();
+        // @DeleteMapping("/users/{id}")
+        // public ResponseEntity<?> deleteUsers(
+        // @PathVariable String id,
+        // Authentication authentication) {
+        // String token = tokenService.getAccessToken();
 
-                return restClient.delete()
-                                .uri(uriBuilder -> uriBuilder
-                                                .path("/users/{id}")
-                                                .build(id))
+        // return restClient.delete()
+        // .uri(uriBuilder -> uriBuilder
+        // .path("/users/{id}")
+        // .build(id))
+        // .header("Authorization", "Bearer " + token)
+        // .retrieve()
+        // .onStatus(status -> !status.is2xxSuccessful(),
+        // (request, response) -> {
+        // byte[] body_bytes = response.getBody().readAllBytes();
+        // if (response.getStatusCode().is4xxClientError()) {
+        // throw new HttpClientErrorException(
+        // response.getStatusCode(),
+        // response.getStatusText(),
+        // response.getHeaders(), body_bytes,
+        // StandardCharsets.UTF_8);
+        // } else {
+        // throw new HttpServerErrorException(
+        // response.getStatusCode(),
+        // response.getStatusText(),
+        // response.getHeaders(), body_bytes,
+        // StandardCharsets.UTF_8);
+        // }
+        // })
+        // .toBodilessEntity();
+        // }
+
+        @DeleteMapping("/users/{id}")
+        public Mono<ResponseEntity<String>> deleteUser(
+                        @PathVariable String id,
+                        Authentication authentication,
+                        HttpServletRequest request,
+                        @RequestHeader HttpHeaders headers) {
+                String token = tokenService.getAccessToken();
+                String url = props.apiBaseUrl() + "/users/" + id;
+                return webClient.delete()
+                                .uri(url)
                                 .header("Authorization", "Bearer " + token)
-                                .retrieve()
-                                .toEntity(Object.class);
+                                .exchangeToMono(response -> response.bodyToMono(String.class)
+                                                .defaultIfEmpty("")
+                                                .map(body -> ResponseEntity
+                                                                .status(response.statusCode())
+                                                                .body(body)));
         }
+
+        // ----------------------------------------------------------------------------
+
+        // //initial template
+        // @DeleteMapping("/proxy/**")
+        // public Mono<ResponseEntity<String>> proxyDelete(
+        // HttpServletRequest request,
+        // @RequestHeader HttpHeaders headers) {
+        // String url = "https://api.com" + request.getRequestURI().replace("/proxy",
+        // "");
+
+        // return forwardRequest(HttpMethod.DELETE, url, headers, null);
+        // }
+
+        // ----------------------------------------------------------------------------
 
         // get user
+        // @GetMapping("/users/{id}")
+        // public ResponseEntity<?> getUser(
+        // @PathVariable String id,
+        // Authentication authentication) {
+        // String token = tokenService.getAccessToken();
+
+        // return restClient.get()
+        // .uri(uriBuilder -> uriBuilder
+        // .path("/users/{id}")
+        // .build(id))
+        // .header("Authorization", "Bearer " + token)
+        // .retrieve()
+        // .onStatus(status -> !status.is2xxSuccessful(),
+        // (request, response) -> {
+        // byte[] body_bytes = response.getBody().readAllBytes();
+        // if (response.getStatusCode().is4xxClientError()) {
+        // throw new HttpClientErrorException(
+        // response.getStatusCode(),
+        // response.getStatusText(),
+        // response.getHeaders(), body_bytes,
+        // StandardCharsets.UTF_8);
+        // } else {
+        // throw new HttpServerErrorException(
+        // response.getStatusCode(),
+        // response.getStatusText(),
+        // response.getHeaders(), body_bytes,
+        // StandardCharsets.UTF_8);
+        // }
+        // })
+        // .toEntity(Object.class);
+        // }
+
         @GetMapping("/users/{id}")
-        public ResponseEntity<?> getUser(
+        public Mono<ResponseEntity<String>> getUser(
                         @PathVariable String id,
-                        Authentication authentication) {
+                        Authentication authentication,
+                        HttpServletRequest request,
+                        @RequestHeader HttpHeaders headers) {
                 String token = tokenService.getAccessToken();
-
-                return restClient.get()
-                                .uri(uriBuilder -> uriBuilder
-                                                .path("/users/{id}")
-                                                .build(id))
+                String url = props.apiBaseUrl() + "/users/" + id;
+                return webClient.get()
+                                .uri(url)
                                 .header("Authorization", "Bearer " + token)
-                                .retrieve()
-                                .toEntity(Object.class);
+                                .exchangeToMono(response -> response.bodyToMono(String.class)
+                                                .defaultIfEmpty("")
+                                                .map(body -> ResponseEntity
+                                                                .status(response.statusCode())
+                                                                .body(body)));
         }
 
+        // ------------------------------------------------------------------------------------
         // update user details
-        @PatchMapping("/users/{id}")
-        public ResponseEntity<?> updateUserDetails(
-                        @PathVariable String id,
-                        @RequestBody Object body, // Accepts any {} or []
-                        Authentication authentication) {
-                String token = tokenService.getAccessToken();
+        // @PatchMapping("/users/{id}")
+        // public ResponseEntity<?> updateUserDetails(
+        // @PathVariable String id,
+        // @RequestBody Object body, // Accepts any {} or []
+        // Authentication authentication) {
+        // String token = tokenService.getAccessToken();
 
-                return restClient.patch()
-                                .uri(uriBuilder -> uriBuilder
-                                                .path("/users/{id}")
-                                                .build(id))
+        // return restClient.patch()
+        // .uri(uriBuilder -> uriBuilder
+        // .path("/users/{id}")
+        // .build(id))
+        // .header("Authorization", "Bearer " + token)
+        // .body(body)
+        // .retrieve()
+        // .onStatus(status -> !status.is2xxSuccessful(),
+        // (request, response) -> {
+        // byte[] body_bytes = response.getBody().readAllBytes();
+        // if (response.getStatusCode().is4xxClientError()) {
+        // throw new HttpClientErrorException(
+        // response.getStatusCode(),
+        // response.getStatusText(),
+        // response.getHeaders(), body_bytes,
+        // StandardCharsets.UTF_8);
+        // } else {
+        // throw new HttpServerErrorException(
+        // response.getStatusCode(),
+        // response.getStatusText(),
+        // response.getHeaders(), body_bytes,
+        // StandardCharsets.UTF_8);
+        // }
+        // })
+        // .toEntity(Object.class);
+        // }
+
+        @PatchMapping("/users/{id}")
+        public Mono<ResponseEntity<String>> updateUserDetails(
+                        @PathVariable String id,
+                        @RequestBody String body,
+                        Authentication authentication,
+                        HttpServletRequest request,
+                        @RequestHeader HttpHeaders headers) {
+                String token = tokenService.getAccessToken();
+                String url = props.apiBaseUrl() + "/users/" + id;
+                return webClient.patch()
+                                .uri(url)
                                 .header("Authorization", "Bearer " + token)
-                                .body(body)
-                                .retrieve()
-                                .toEntity(Object.class);
+                                .header("Content-Type", "application/json")
+                                .bodyValue(body)
+                                .exchangeToMono(response -> response.bodyToMono(String.class)
+                                                .defaultIfEmpty("")
+                                                .map(b -> ResponseEntity
+                                                                .status(response.statusCode())
+                                                                .body(b)));
         }
+
+        // ---------------------------------------------------------------------------------
 
         private Auth0UserResponse toUserResponse(Auth0UserDto dto) {
                 Auth0UserResponse response = Auth0UserResponse.builder()
@@ -231,56 +408,190 @@ public class Auth0ManagementController {
 
         }
 
+        // ------------------------------------------------------------------------
         // remove user role
+        // @DeleteMapping("/users/{id}/roles")
+        // public ResponseEntity<?> removeUserRole(
+        // @PathVariable String id,
+        // @RequestBody Object body, // to get the role id
+        // Authentication authentication) {
+        // String token = tokenService.getAccessToken();
+
+        // return restClient.method(HttpMethod.DELETE) // other delete did not support
+        // body
+        // .uri(uriBuilder -> uriBuilder
+        // .path("/users/{id}/roles")
+        // .build(id))
+        // .header("Authorization", "Bearer " + token)
+        // .body(body)
+        // .retrieve()
+        // .onStatus(status -> !status.is2xxSuccessful(),
+        // (request, response) -> {
+        // byte[] body_bytes = response.getBody().readAllBytes();
+        // if (response.getStatusCode().is4xxClientError()) {
+        // throw new HttpClientErrorException(
+        // response.getStatusCode(),
+        // response.getStatusText(),
+        // response.getHeaders(), body_bytes,
+        // StandardCharsets.UTF_8);
+        // } else {
+        // throw new HttpServerErrorException(
+        // response.getStatusCode(),
+        // response.getStatusText(),
+        // response.getHeaders(), body_bytes,
+        // StandardCharsets.UTF_8);
+        // }
+        // })
+        // .toBodilessEntity();
+        // }
+
+
         @DeleteMapping("/users/{id}/roles")
-        public ResponseEntity<?> removeUserRole(
+        public Mono<ResponseEntity<String>> removeUserRole(
                         @PathVariable String id,
-                        @RequestBody Object body, // to get the role id
-                        Authentication authentication) {
+                        @RequestBody String body,
+                        Authentication authentication,
+                        HttpServletRequest request,
+                        @RequestHeader HttpHeaders headers) {
                 String token = tokenService.getAccessToken();
-
-                return restClient.method(HttpMethod.DELETE) // other delete did not support body
-                                .uri(uriBuilder -> uriBuilder
-                                                .path("/users/{id}/roles")
-                                                .build(id))
+                String url = props.apiBaseUrl() + "/users/" + id + "/roles";
+                return webClient.method(HttpMethod.DELETE)
+                                .uri(url)
                                 .header("Authorization", "Bearer " + token)
-                                .body(body)
-                                .retrieve()
-                                .toEntity(Object.class);
+                                .header("Content-Type", "application/json")
+                                .bodyValue(body)
+                                .exchangeToMono(response -> response.bodyToMono(String.class)
+                                                .defaultIfEmpty("")
+                                                .map(b -> ResponseEntity
+                                                                .status(response.statusCode())
+                                                                .body(b)));
         }
+        /*
+        {
+        "roles": [
+                "string"
+                ]
+        }
+        */
 
+        // ----------------------------------------------------------------------------------
         // assign a role for the user
+        // @PostMapping("/users/{id}/roles")
+        // public ResponseEntity<?> assignRole(
+        // @PathVariable String id,
+        // @RequestBody Object body, // to get user id
+        // Authentication authentication) {
+        // String token = tokenService.getAccessToken();
+
+        // return restClient.post()
+        // .uri(uriBuilder -> uriBuilder
+        // .path("/users/{id}/roles")
+        // .build(id))
+        // .header("Authorization", "Bearer " + token)
+        // .body(body)
+        // .retrieve()
+        // .onStatus(status -> !status.is2xxSuccessful(),
+        // (request, response) -> {
+        // byte[] body_bytes = response.getBody().readAllBytes();
+        // if (response.getStatusCode().is4xxClientError()) {
+        // throw new HttpClientErrorException(
+        // response.getStatusCode(),
+        // response.getStatusText(),
+        // response.getHeaders(), body_bytes,
+        // StandardCharsets.UTF_8);
+        // } else {
+        // throw new HttpServerErrorException(
+        // response.getStatusCode(),
+        // response.getStatusText(),
+        // response.getHeaders(), body_bytes,
+        // StandardCharsets.UTF_8);
+        // }
+        // })
+        // .toEntity(Object.class);
+        // }
+
         @PostMapping("/users/{id}/roles")
-        public ResponseEntity<?> assignRole(
+        public Mono<ResponseEntity<String>> assignRole(
                         @PathVariable String id,
-                        @RequestBody Object body, // to get user id
-                        Authentication authentication) {
+                        @RequestBody String body,
+                        Authentication authentication,
+                        HttpServletRequest request,
+                        @RequestHeader HttpHeaders headers) {
                 String token = tokenService.getAccessToken();
-
-                return restClient.post()
-                                .uri(uriBuilder -> uriBuilder
-                                                .path("/users/{id}/roles")
-                                                .build(id))
+                String url = props.apiBaseUrl() + "/users/" + id + "/roles";
+                return webClient.post()
+                                .uri(url)
                                 .header("Authorization", "Bearer " + token)
-                                .body(body)
-                                .retrieve()
-                                .toEntity(Object.class);
+                                .header("Content-Type", "application/json")
+                                .bodyValue(body)
+                                .exchangeToMono(response -> response.bodyToMono(String.class)
+                                                .defaultIfEmpty("")
+                                                .map(b -> ResponseEntity
+                                                                .status(response.statusCode())
+                                                                .body(b)));
         }
 
+
+
+        /*
+        {
+        "roles": [
+                "string"
+                ]
+        }
+        */
+
+        // --------------------------------------------------------------------------------
         // get all roles
-        @GetMapping("/roles")
-        public ResponseEntity<?> getRoles(
-                        Authentication authentication) {
-                String token = tokenService.getAccessToken();
+        // @GetMapping("/roles")
+        // public ResponseEntity<?> getRoles(
+        // Authentication authentication) {
+        // String token = tokenService.getAccessToken();
 
-                return restClient.get()
-                                .uri(uriBuilder -> uriBuilder
-                                                .path("/roles")
-                                                .build())
+        // return restClient.get()
+        // .uri(uriBuilder -> uriBuilder
+        // .path("/roles")
+        // .build())
+        // .header("Authorization", "Bearer " + token)
+        // .retrieve()
+        // .onStatus(status -> !status.is2xxSuccessful(),
+        // (request, response) -> {
+        // byte[] body_bytes = response.getBody().readAllBytes();
+        // if (response.getStatusCode().is4xxClientError()) {
+        // throw new HttpClientErrorException(
+        // response.getStatusCode(),
+        // response.getStatusText(),
+        // response.getHeaders(), body_bytes,
+        // StandardCharsets.UTF_8);
+        // } else {
+        // throw new HttpServerErrorException(
+        // response.getStatusCode(),
+        // response.getStatusText(),
+        // response.getHeaders(), body_bytes,
+        // StandardCharsets.UTF_8);
+        // }
+        // })
+        // .toEntity(Object.class);
+        // }
+
+        @GetMapping("/roles")
+        public Mono<ResponseEntity<String>> getRoles(
+                        Authentication authentication,
+                        HttpServletRequest request,
+                        @RequestHeader HttpHeaders headers) {
+                String token = tokenService.getAccessToken();
+                String url = props.apiBaseUrl() + "/roles";
+                return webClient.get()
+                                .uri(url)
                                 .header("Authorization", "Bearer " + token)
-                                .retrieve()
-                                .toEntity(Object.class);
+                                .exchangeToMono(response -> response.bodyToMono(String.class)
+                                                .defaultIfEmpty("")
+                                                .map(body -> ResponseEntity
+                                                                .status(response.statusCode())
+                                                                .body(body)));
         }
+
+        // -------------------------------------------------------------------------
 
         private Auth0RoleResponse toRoleResponse(Auth0RoleDto dto) {
                 Auth0RoleResponse response = Auth0RoleResponse.builder()
@@ -326,9 +637,23 @@ public class Auth0ManagementController {
         @ExceptionHandler(HttpStatusCodeException.class)
         public ResponseEntity<?> handleAuth0SpecificError(HttpStatusCodeException ex) {
                 // This will ONLY trigger for errors in THIS controller
+                Map<String, Object> errorResponse = new HashMap<>();
+                errorResponse.put("statusCode", ex.getStatusCode().value());
+
+                try {
+                        Object auth0Response = ex.getResponseBodyAs(Object.class);
+                        if (auth0Response instanceof Map) {
+                                Map<String, Object> auth0Map = (Map<String, Object>) auth0Response;
+                                errorResponse.putAll(auth0Map);
+                        }
+                } catch (Exception e) {
+                        errorResponse.put("error", ex.getStatusText());
+                        errorResponse.put("message", ex.getMessage());
+                }
+
                 return ResponseEntity
                                 .status(ex.getStatusCode())
-                                .body(ex.getResponseBodyAs(Object.class));
+                                .body(errorResponse);
         }
 
 }

--- a/backend/src/main/java/com/smartcampus/backend/controller/BookingController.java
+++ b/backend/src/main/java/com/smartcampus/backend/controller/BookingController.java
@@ -13,15 +13,11 @@ import org.springframework.web.bind.annotation.*;
 import java.util.*;
 
 /**
- * REST Controller for Booking Management API.
- * Implements Module B endpoints:
  * - POST /api/bookings - Create booking
  * - GET /api/bookings - List bookings with filtering
  * - GET /api/bookings/me - List current user's bookings (derived from JWT)
  * - GET /api/bookings/{id} - Get booking details
  * - PATCH /api/bookings/{id}/status - Update booking status
- * 
- * Follows REST architectural constraints with HATEOAS links and proper HTTP semantics.
  */
 @RestController
 @RequestMapping("/api/bookings")
@@ -291,20 +287,20 @@ public class BookingController {
         }
     }
     
-    // ============ Helper Methods ============
+    // ------------------------------------------------------------------
     
-    /**
-     * Helper to create HATEOAS link map.
-     */
+    
+     // Helper to create HATEOAS link map.
+     
     private Map<String, String> createLink(String href) {
         Map<String, String> link = new HashMap<>();
         link.put("href", href);
         return link;
     }
     
-    /**
-     * Helper to create HATEOAS link with HTTP method.
-     */
+    
+     // Helper to create HATEOAS link with HTTP method.
+     
     private Map<String, String> createLinkWithMethod(String href, String method) {
         Map<String, String> link = new HashMap<>();
         link.put("href", href);
@@ -312,9 +308,9 @@ public class BookingController {
         return link;
     }
     
-    /**
-     * Helper to build query string for pagination.
-     */
+    
+     // Helper to build query string for pagination.
+     
     private String buildQueryString(String status, String resourceId, String userId, int page, int limit) {
         StringBuilder sb = new StringBuilder("?");
         boolean first = true;
@@ -342,9 +338,9 @@ public class BookingController {
         return sb.toString();
     }
 
-    /**
-     * Build query string for /api/bookings/me links.
-     */
+    
+     //Build query string for /api/bookings/me links.
+
     private String buildMyBookingsQueryString(String status, String resourceId, int page, int limit) {
         return buildQueryString(status, resourceId, null, page, limit);
     }

--- a/backend/src/main/java/com/smartcampus/backend/controller/FileUploadController.java
+++ b/backend/src/main/java/com/smartcampus/backend/controller/FileUploadController.java
@@ -21,18 +21,16 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * REST Controller for File & Media Management (Module F).
- *
- * Endpoints:
- *   POST   /api/upload            – Upload an image to Minio, get back a generated file name.
- *   DELETE /api/upload/{fileName} – Remove an orphan file from Minio before ticket submission.
- *
- * The upload endpoint is called BEFORE the ticket is created.
- * The frontend collects the returned generatedFileNames and sends them
- * inside CreateTicketRequest.attachments when submitting the ticket form.
- *
- * Allowed file types: JPEG, PNG, GIF, WEBP (images only – per assignment spec).
- * Max file size: 10 MB (configured in application.properties).
+  Endpoints:
+    POST   /api/upload            – Upload an image to Minio, get back a generated file name.
+    DELETE /api/upload/{fileName} – Remove an orphan file from Minio before ticket submission.
+ 
+  The upload endpoint is called BEFORE the ticket is created.
+  The frontend collects the returned generatedFileNames and sends them
+  inside CreateTicketRequest.attachments when submitting the ticket form.
+ 
+  Allowed file types: JPEG, PNG, GIF, WEBP (images only – per assignment spec).
+  Max file size: 10 MB (configured in application.properties).
  */
 @RestController
 @RequestMapping("/api/upload")
@@ -52,15 +50,15 @@ public class FileUploadController {
     // ── POST /api/upload ──────────────────────────────────────────────────────
 
     /**
-     * Uploads a file to Minio and returns the generated unique file name.
-     *
-     * The generated name format is: {epochSeconds}_{userId}_{originalName}.{ext}
-     * Example: 1711025800_usr1001_tint1.jpg
-     *
-     * Status Codes:
-     *   201 Created     – File uploaded successfully.
-     *   400 Bad Request – No file, wrong type, or file too large.
-     *   500 Internal    – Minio error.
+      Uploads a file to Minio and returns the generated unique file name.
+     
+      The generated name format is: {epochSeconds}_{userId}_{originalName}.{ext}
+      Example: 1711025800_usr1001_tint1.jpg
+     
+      Status Codes:
+        201 Created     – File uploaded successfully.
+        400 Bad Request – No file, wrong type, or file too large.
+        500 Internal    – Minio error.
      */
     @PostMapping(consumes = "multipart/form-data")
     public ResponseEntity<ApiResponse<FileUploadResponse>> uploadFile(
@@ -140,15 +138,15 @@ public class FileUploadController {
     // ── DELETE /api/upload/{fileName} ─────────────────────────────────────────
 
     /**
-     * Deletes an uploaded file from Minio before it is linked to a ticket.
-     *
-     * Called when the user removes an image from their ticket form
-     * before submitting – cleans up the orphan file in Minio.
-     *
-     * Status Codes:
-     *   200 OK          – File deleted from Minio.
-     *   400 Bad Request – Invalid file name.
-     *   500 Internal    – Minio error.
+      Deletes an uploaded file from Minio before it is linked to a ticket.
+     
+      Called when the user removes an image from their ticket form
+      before submitting – cleans up the orphan file in Minio.
+     
+      Status Codes:
+        200 OK          – File deleted from Minio.
+        400 Bad Request – Invalid file name.
+        500 Internal    – Minio error.
      */
     @DeleteMapping("/{fileName}")
     public ResponseEntity<ApiResponse<Map<String, String>>> deleteFile(
@@ -212,7 +210,7 @@ public class FileUploadController {
         }
     }
 
-    // ── Helpers ───────────────────────────────────────────────────────────────
+    // Helpers
 
     private Map<String, String> createLink(String href) {
         Map<String, String> link = new HashMap<>();

--- a/backend/src/main/java/com/smartcampus/backend/controller/ResourceAnalyticsController.java
+++ b/backend/src/main/java/com/smartcampus/backend/controller/ResourceAnalyticsController.java
@@ -28,20 +28,20 @@ public class ResourceAnalyticsController {
     private BookingRepository bookingRepository;
 
     /**
-     * GET /api/analytics/resources
-     * Returns comprehensive resource analytics for admin dashboard
-     * Includes: total count, distribution by type/status, most booked resources, utilization
+      GET /api/analytics/resources
+       resource analytics for admin dashboard
+      Includes: total count, distribution by type/status, most booked resources, utilization
      */
     @GetMapping
     public ResponseEntity<Map<String, Object>> getResourceAnalytics(Authentication authentication) {
         Map<String, Object> analytics = new HashMap<>();
 
         try {
-            // 1. Total resources count
+            //  Total resources count
             long totalResources = resourceRepository.countTotal();
             analytics.put("totalResources", totalResources);
 
-            // 2. Resources distribution by type
+            //  Resources distribution by type
             Map<String, Long> typeDistribution = resourceRepository.countByType()
                     .stream()
                     .collect(Collectors.toMap(
@@ -50,7 +50,7 @@ public class ResourceAnalyticsController {
                     ));
             analytics.put("typeDistribution", typeDistribution);
 
-            // 3. Resources distribution by status
+            // Resources distribution by status
             Map<String, Long> statusDistribution = resourceRepository.countByStatus()
                     .stream()
                     .collect(Collectors.toMap(
@@ -59,7 +59,7 @@ public class ResourceAnalyticsController {
                     ));
             analytics.put("statusDistribution", statusDistribution);
 
-            // 4. Most booked resources (using existing booking analytics)
+            //  Most booked resources (using existing booking analytics)
             List<Object[]> mostBookedResources = bookingRepository.findMostBookedResources();
             List<Map<String, Object>> mostBooked = mostBookedResources.stream()
                     .map(result -> {
@@ -72,7 +72,7 @@ public class ResourceAnalyticsController {
                     .collect(Collectors.toList());
             analytics.put("mostBookedResources", mostBooked);
 
-            // 5. Recently added resources
+            // Recently added resources
             List<Map<String, Object>> recentlyAdded = resourceRepository.findRecentlyAdded()
                     .stream()
                     .map(resource -> {
@@ -87,7 +87,7 @@ public class ResourceAnalyticsController {
                     .collect(Collectors.toList());
             analytics.put("recentlyAdded", recentlyAdded);
 
-            // 6. Average capacity per resource type
+            // Average capacity per resource type
             Map<String, Double> avgCapacityByType = new HashMap<>();
             List<Map<String, Object>> typeCapacityData = resourceRepository.findAll()
                     .stream()
@@ -107,7 +107,7 @@ public class ResourceAnalyticsController {
                     .collect(Collectors.toList());
             analytics.put("avgCapacityByType", typeCapacityData);
 
-            // 7. Active vs Inactive resources
+            // Active vs Inactive resources
             Map<String, Long> activeStatus = statusDistribution;
             analytics.put("activeResources", activeStatus.getOrDefault("ACTIVE", 0L));
             analytics.put("inactiveResources", activeStatus.getOrDefault("OUT_OF_SERVICE", 0L));

--- a/backend/src/main/java/com/smartcampus/backend/controller/ResourceController.java
+++ b/backend/src/main/java/com/smartcampus/backend/controller/ResourceController.java
@@ -10,15 +10,12 @@ import org.springframework.web.bind.annotation.*;
 import java.util.*;
 
 /*
- * REST Controller for Resource Management API.
- * Implements Module A endpoints:
- * - GET /api/resources - List resources with filtering
- * - GET /api/resources/{id} - Get resource details
- * - POST /api/resources - Create resource
- * - PUT /api/resources/{id} - Update resource
- * - DELETE /api/resources/{id} - Delete resource
- * 
- * Follows REST architectural constraints with HATEOAS links and proper HTTP semantics.
+  Implements Module A endpoints:
+  - GET /api/resources - List resources with filtering
+  - GET /api/resources/{id} - Get resource details
+  - POST /api/resources - Create resource
+  - PUT /api/resources/{id} - Update resource
+  - DELETE /api/resources/{id} - Delete resource
  */
 
 @RestController
@@ -30,18 +27,18 @@ public class ResourceController {
     private ResourceService resourceService;
 
         /**
-     * GET /api/resources
-     * List resources with optional filtering and pagination.
-     * 
-     * Query Parameters:
-     * - type: Filter by type (ROOM, LAB, EQUIPMENT)
-     * - status: Filter by status (ACTIVE, OUT_OF_SERVICE)
-     * - minCapacity: Filter by minimum capacity
-     * - page: Page number (1-indexed), default 1
-     * - limit: Items per page, default 10
-     * 
-     * Status Codes:
-     * - 200 OK: Successfully retrieved resources
+    * GET /api/resources
+     List resources with optional filtering and pagination.
+     
+     Query Parameters:
+      - type: Filter by type (ROOM, LAB, EQUIPMENT)
+      - status: Filter by status (ACTIVE, OUT_OF_SERVICE)
+      - minCapacity: Filter by minimum capacity
+      - page: Page number (1-indexed), default 1
+      - limit: Items per page, default 10
+      
+      Status Codes:
+      - 200 OK: Successfully retrieved resources
      */
     @GetMapping
     public ResponseEntity<ApiResponse<ListResourcesResponse>> listResources(

--- a/backend/src/main/java/com/smartcampus/backend/controller/TicketController.java
+++ b/backend/src/main/java/com/smartcampus/backend/controller/TicketController.java
@@ -15,26 +15,19 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 
 /**
- * REST Controller for Maintenance & Incident Ticketing (Module C).
- *
- * Endpoints implemented:
- *
- *   Tickets:
- *     POST   /api/tickets              – Create a new incident ticket
- *     GET    /api/tickets              – List tickets (with filters + pagination)
- *     GET    /api/tickets/{id}         – Get full ticket details
- *     PATCH  /api/tickets/{id}         – Update status / assign technician / add notes
- *     DELETE /api/tickets/{id}         – Delete a ticket (admin only)
- *
- *   Comments:
- *     POST   /api/tickets/{id}/comments              – Add a comment
- *     GET    /api/tickets/{id}/comments              – List all comments on a ticket
- *     PATCH  /api/tickets/{id}/comments/{commentId}  – Edit own comment
- *     DELETE /api/tickets/{id}/comments/{commentId}  – Delete own comment (or admin any)
- *
- * All responses follow the ApiResponse<T> wrapper used across the project.
- * HATEOAS _links are included on every response.
- * Cache-Control: no-store is set on all ticket endpoints (data changes frequently).
+
+   Tickets:
+      POST   /api/tickets              – Create a new incident ticket
+      GET    /api/tickets              – List tickets (with filters + pagination)
+      GET    /api/tickets/{id}         – Get full ticket details
+      PATCH  /api/tickets/{id}         – Update status / assign technician / add notes
+      DELETE /api/tickets/{id}         – Delete a ticket (admin only)
+ 
+    Comments:
+      POST   /api/tickets/{id}/comments              – Add a comment
+      GET    /api/tickets/{id}/comments              – List all comments on a ticket
+      PATCH  /api/tickets/{id}/comments/{commentId}  – Edit own comment
+      DELETE /api/tickets/{id}/comments/{commentId}  – Delete own comment (or admin any)
  */
 @RestController
 @RequestMapping("/api/tickets")
@@ -44,26 +37,26 @@ public class TicketController {
     @Autowired
     private TicketService ticketService;
 
-    // ── POST /api/tickets ─────────────────────────────────────────────────────
+    // POST /api/tickets
 
     /**
-     * Create a new incident ticket.
-     *
-     * Request body example:
-     * {
-     *   "resourceId": "res_room_01",          (optional)
-     *   "location": "Building 1, Floor 2",    (optional if resourceId is given)
-     *   "category": "HARDWARE",
-     *   "priority": "HIGH",
-     *   "description": "Projector is flickering.",
-     *   "contactPhone": "555-0192",
-     *   "attachments": ["1711025800_usr1001_tint1.jpg"]  (pre-uploaded, max 3)
-     * }
-     *
-     * Status Codes:
-     *   201 Created     – Ticket created successfully.
-     *   400 Bad Request – Validation failed.
-     *   500 Internal    – Unexpected error.
+      Create a new incident ticket.
+     
+      Request body example:
+      {
+        "resourceId": "res_room_01",          (optional)
+        "location": "Building 1, Floor 2",    (optional if resourceId is given)
+        "category": "HARDWARE",
+        "priority": "HIGH",
+        "description": "Projector is flickering.",
+        "contactPhone": "555-0192",
+        "attachments": ["1711025800_usr1001_tint1.jpg"]  (pre-uploaded, max 3)
+      }
+     
+      Status Codes:
+        201 Created     – Ticket created successfully.
+        400 Bad Request – Validation failed.
+        500 Internal    – Unexpected error.
      */
     @PostMapping
     public ResponseEntity<ApiResponse<TicketResponse>> createTicket(
@@ -102,23 +95,23 @@ public class TicketController {
         }
     }
 
-    // ── GET /api/tickets ──────────────────────────────────────────────────────
+    // GET /api/tickets
 
     /**
-     * List tickets with optional filters and pagination.
-     *
-     * Query parameters (all optional):
-     *   status     – OPEN | IN_PROGRESS | RESOLVED | CLOSED | REJECTED
-     *   createdBy  – filter to one user's tickets (USER sees only their own)
-     *   assignedTo – filter to a technician's queue
-     *   resourceId – filter to tickets for a specific resource
-     *   page       – page number, default 1
-     *   limit      – items per page, default 10
-     *
-     * Status Codes:
-     *   200 OK          – List returned (may be empty).
-     *   400 Bad Request – Invalid filter value.
-     *   500 Internal    – Unexpected error.
+      List tickets with optional filters and pagination.
+     
+      Query parameters (all optional):
+        status     – OPEN | IN_PROGRESS | RESOLVED | CLOSED | REJECTED
+        createdBy  – filter to one user's tickets (USER sees only their own)
+        assignedTo – filter to a technician's queue
+        resourceId – filter to tickets for a specific resource
+        page       – page number, default 1
+        limit      – items per page, default 10
+     
+      Status Codes:
+        200 OK          – List returned (may be empty).
+        400 Bad Request – Invalid filter value.
+        500 Internal    – Unexpected error.
      */
     @GetMapping
     public ResponseEntity<ApiResponse<ListTicketsResponse>> listTickets(
@@ -216,15 +209,15 @@ public class TicketController {
         }
     }
 
-    // ── GET /api/tickets/{id} ─────────────────────────────────────────────────
+    // GET /api/tickets/{id}
 
     /**
-     * Get full details for a single ticket (includes comments and attachments).
-     *
-     * Status Codes:
-     *   200 OK    – Ticket found and returned.
-     *   404 Not Found – Ticket does not exist.
-     *   500 Internal  – Unexpected error.
+      Get full details for a single ticket (includes comments and attachments).
+     
+      Status Codes:
+        200 OK    – Ticket found and returned.
+        404 Not Found – Ticket does not exist.
+        500 Internal  – Unexpected error.
      */
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<TicketResponse>> getTicket(
@@ -258,24 +251,24 @@ public class TicketController {
         }
     }
 
-    // ── PATCH /api/tickets/{id} ───────────────────────────────────────────────
+    // PATCH /api/tickets/{id} 
 
     /**
-     * Partially update a ticket.
-     * Used by ADMIN to approve/reject/assign and by TECHNICIAN to add resolution notes.
-     *
-     * Request body (all fields optional):
-     * {
-     *   "status": "IN_PROGRESS",
-     *   "assignedTo": "usr_9001",
-     *   "resolutionNotes": "Investigating the bulb connection."
-     * }
-     *
-     * Status Codes:
-     *   200 OK          – Ticket updated.
-     *   400 Bad Request – Invalid status or transition.
-     *   404 Not Found   – Ticket not found.
-     *   500 Internal    – Unexpected error.
+      update a ticket.
+      Used by ADMIN to approve/reject/assign and by TECHNICIAN to add resolution notes.
+     
+      Request body (all fields optional):
+      {
+        "status": "IN_PROGRESS",
+        "assignedTo": "usr_9001",
+        "resolutionNotes": "Investigating the bulb connection."
+      }
+     
+      Status Codes:
+        200 OK          – Ticket updated.
+        400 Bad Request – Invalid status or transition.
+        404 Not Found   – Ticket not found.
+        500 Internal    – Unexpected error.
      */
     @PatchMapping("/{id}")
     public ResponseEntity<ApiResponse<TicketResponse>> updateTicket(
@@ -308,16 +301,16 @@ public class TicketController {
         }
     }
 
-    // ── DELETE /api/tickets/{id} ──────────────────────────────────────────────
+    //  DELETE /api/tickets/{id} 
 
     /**
-     * Delete a ticket (admin only).
-     * Also removes all associated attachment files from Minio.
-     *
-     * Status Codes:
-     *   204 No Content – Ticket deleted.
-     *   404 Not Found  – Ticket not found.
-     *   500 Internal   – Unexpected error.
+      Delete a ticket (admin only).
+      Also removes all associated attachment files from Minio.
+     
+      Status Codes:
+        204 No Content – Ticket deleted.
+        404 Not Found  – Ticket not found.
+        500 Internal   – Unexpected error.
      */
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteTicket(@PathVariable String id) {
@@ -331,19 +324,19 @@ public class TicketController {
         }
     }
 
-    // ── POST /api/tickets/{id}/comments ──────────────────────────────────────
+    //  POST /api/tickets/{id}/comments
 
     /**
-     * Add a comment to a ticket.
-     * Any authenticated user (USER / ADMIN / TECHNICIAN) can comment.
-     *
-     * Request body: { "text": "I will check this out by 2 PM." }
-     *
-     * Status Codes:
-     *   201 Created     – Comment added.
-     *   400 Bad Request – Empty text.
-     *   404 Not Found   – Ticket not found.
-     *   500 Internal    – Unexpected error.
+     Add a comment to a ticket.
+     Any authenticated user (USER / ADMIN / TECHNICIAN) can comment.
+     
+      Request body: { "text": "I will check this out by 2 PM." }
+     
+      Status Codes:
+        201 Created     – Comment added.
+        400 Bad Request – Empty text.
+        404 Not Found   – Ticket not found.
+        500 Internal    – Unexpected error.
      */
     @PostMapping("/{id}/comments")
     public ResponseEntity<ApiResponse<TicketCommentResponse>> addComment(
@@ -395,15 +388,15 @@ public class TicketController {
         }
     }
 
-    // ── GET /api/tickets/{id}/comments ───────────────────────────────────────
+    //  GET /api/tickets/{id}/comments 
 
     /**
-     * List all comments on a ticket (oldest first).
-     *
-     * Status Codes:
-     *   200 OK        – List returned (may be empty).
-     *   404 Not Found – Ticket not found.
-     *   500 Internal  – Unexpected error.
+      List all comments on a ticket (oldest first).
+     
+      Status Codes:
+        200 OK        – List returned (may be empty).
+        404 Not Found – Ticket not found.
+        500 Internal  – Unexpected error.
      */
     @GetMapping("/{id}/comments")
     public ResponseEntity<ApiResponse<List<TicketCommentResponse>>> listComments(

--- a/backend/src/main/java/com/smartcampus/backend/repository/BookingRepository.java
+++ b/backend/src/main/java/com/smartcampus/backend/repository/BookingRepository.java
@@ -15,33 +15,33 @@ import java.util.List;
 public interface BookingRepository extends JpaRepository<Booking, String> {
 
     /**
-     * Find all bookings by user ID
+     Find all bookings by user ID
      */
     List<Booking> findByUserId(String userId);
 
     /**
-     * Find all bookings by resource ID
+     Find all bookings by resource ID
      */
     List<Booking> findByResourceId(String resourceId);
 
     /**
-     * Find all bookings by status
+      Find all bookings by status
      */
     List<Booking> findByStatus(String status);
 
     /**
-     * Find bookings by user ID and status
+      Find bookings by user ID and status
      */
     List<Booking> findByUserIdAndStatus(String userId, String status);
 
     /**
-     * Find bookings by resource ID and status
+      Find bookings by resource ID and status
      */
     List<Booking> findByResourceIdAndStatus(String resourceId, String status);
 
     /**
-     * Check for overlapping bookings on the same resource
-     * Returns bookings that overlap with the given time window
+     Check for overlapping bookings on the same resource
+      Returns bookings that overlap with the given time window
      */
     @Query("SELECT b FROM Booking b WHERE b.resourceId = :resourceId " +
             "AND b.status IN ('PENDING', 'APPROVED') " +
@@ -53,7 +53,7 @@ public interface BookingRepository extends JpaRepository<Booking, String> {
             @Param("endTime") LocalDateTime endTime);
 
     /**
-     * Find all bookings for a specific resource within a date range
+      Find all bookings for a specific resource within a date range
      */
     @Query("SELECT b FROM Booking b WHERE b.resourceId = :resourceId " +
             "AND b.startTime >= :startDate " +
@@ -65,7 +65,7 @@ public interface BookingRepository extends JpaRepository<Booking, String> {
             @Param("endDate") LocalDateTime endDate);
 
     // analytics page part below
-    // 1. Most Booked Resources
+    // Most Booked Resources
     @Query(value = "SELECT r.Name, COUNT(*) " +
             "FROM Bookings b " +
             "JOIN Resources r ON r.Id = b.ResourceId " +
@@ -73,11 +73,11 @@ public interface BookingRepository extends JpaRepository<Booking, String> {
             "ORDER BY COUNT(*) DESC", nativeQuery = true)
     List<Object[]> findMostBookedResources();
 
-    // 2. Approval Rate
+    // Approval Rate
     @Query("SELECT b.status, COUNT(b) FROM Booking b GROUP BY b.status")
     List<Object[]> findStatusDistribution();
 
-    // 3. Trends for last 7 days
+    // Trends for last 7 days
     @Query(value = "SELECT CAST(b.StartTime AS DATE) AS [day], COUNT(*) AS [count] " +
             "FROM Bookings b " +
             "WHERE b.StartTime >= DATEADD(DAY, -6, CAST(GETDATE() AS DATE)) " +

--- a/backend/src/main/java/com/smartcampus/backend/repository/TicketCommentRepository.java
+++ b/backend/src/main/java/com/smartcampus/backend/repository/TicketCommentRepository.java
@@ -7,14 +7,14 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 /**
- * Repository for the TicketComment entity.
+  Repository for the TicketComment entity.
  */
 @Repository
 public interface TicketCommentRepository extends JpaRepository<TicketComment, String> {
 
     /**
-     * All comments for a ticket, ordered oldest-first.
-     * This gives a natural conversation thread when displayed in the UI.
+     All comments for a ticket, ordered oldest-first.
+      This gives a natural conversation thread when displayed in the UI.
      */
     List<TicketComment> findByTicketIdOrderByCreatedAtAsc(String ticketId);
 

--- a/backend/src/main/java/com/smartcampus/backend/service/Auth0ManagementApiService.java
+++ b/backend/src/main/java/com/smartcampus/backend/service/Auth0ManagementApiService.java
@@ -1,11 +1,14 @@
 package com.smartcampus.backend.service;
 
 // import java.util.Arrays;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClient;
 
 import com.smartcampus.backend.config.Auth0ManagementProperties;
@@ -68,6 +71,17 @@ public class Auth0ManagementApiService {
                 })
                 .header("Authorization", "Bearer " + token)
                 .retrieve()
+                .onStatus(status -> !status.is2xxSuccessful(), 
+                        (request, response) -> {
+                            byte[] body_bytes = response.getBody().readAllBytes();
+                            if (response.getStatusCode().is4xxClientError()) {
+                                throw new HttpClientErrorException(response.getStatusCode(), 
+                                    response.getStatusText(), response.getHeaders(), body_bytes, StandardCharsets.UTF_8);
+                            } else {
+                                throw new HttpServerErrorException(response.getStatusCode(), 
+                                    response.getStatusText(), response.getHeaders(), body_bytes, StandardCharsets.UTF_8);
+                            }
+                        })
                 .body(new ParameterizedTypeReference<List<Auth0UserDto>>() {
                 });
 
@@ -87,6 +101,17 @@ public class Auth0ManagementApiService {
                         .build(auth0UserId))
                 .header("Authorization", "Bearer " + token)
                 .retrieve()
+                .onStatus(status -> !status.is2xxSuccessful(), 
+                        (request, response) -> {
+                            byte[] body_bytes = response.getBody().readAllBytes();
+                            if (response.getStatusCode().is4xxClientError()) {
+                                throw new HttpClientErrorException(response.getStatusCode(), 
+                                    response.getStatusText(), response.getHeaders(), body_bytes, StandardCharsets.UTF_8);
+                            } else {
+                                throw new HttpServerErrorException(response.getStatusCode(), 
+                                    response.getStatusText(), response.getHeaders(), body_bytes, StandardCharsets.UTF_8);
+                            }
+                        })
                 .body(new ParameterizedTypeReference<List<Auth0RoleDto>>() {
                 });
 

--- a/backend/src/main/java/com/smartcampus/backend/service/BookingService.java
+++ b/backend/src/main/java/com/smartcampus/backend/service/BookingService.java
@@ -19,8 +19,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * Service layer for Booking operations.
- * Handles business logic, validation, and data transformation.
+  for Booking operations.
  */
 @Service
 @Transactional

--- a/backend/src/main/java/com/smartcampus/backend/service/NotificationTemplates.java
+++ b/backend/src/main/java/com/smartcampus/backend/service/NotificationTemplates.java
@@ -38,7 +38,7 @@ public class NotificationTemplates {
         switch (status) {
             case "APPROVED":
                 return """
-                        ## Booking Approved
+                        #### Booking Approved
 
                         Status:`%s`
 
@@ -50,8 +50,8 @@ public class NotificationTemplates {
                         """.formatted(status, baseUrl, resource, reasonMarkdown);
             case "REJECTED":
                 return """
-                        ## Booking Rejected
-                        
+                        #### Booking Rejected
+
                         Status:`%s`
 
                         ---
@@ -62,13 +62,13 @@ public class NotificationTemplates {
                         """.formatted(status, baseUrl, resource, reasonMarkdown);
             case "CANCELLED":
                 return """
-                        ## Booking Cancelled
+                        #### Booking Cancelled
 
                         Status:`%s`
-                        
+
                         ---
 
-                        we are unable to approve your request at this time:
+                        Your Booking was Cancelled.:
                         * **Resource:**  [Click here](%s/resources/%s)
                         %s
                         """.formatted(status, baseUrl, resource, reasonMarkdown);
@@ -82,7 +82,7 @@ public class NotificationTemplates {
         String formattedCreatedAt = formatDateTime(createdAt);
         return """
 
-                ## New Booking Request Received
+                #### New Booking Request Received
 
                 **Status:** `%s`
 
@@ -90,13 +90,13 @@ public class NotificationTemplates {
 
                 Your request to reserve a campus resource has been successfully submitted. Our administration team will review your request shortly.
 
-                ### Request Details:
+                ##### Booking Details:
                 * **Submitted On:** %s
                 * **Resource:**  [Click here](%s/resources/%s)
 
                 ---
 
-                ### Next Steps
+                ##### Next Steps
                 1. **Verification:** Our team checks for scheduling conflicts or maintenance windows.
                 2. **Notification:** You will receive an notification once the status changes to **Approved** or **Rejected**.
                 3. **Check Status:** You can monitor this request at any time via the my bookings page.
@@ -106,5 +106,43 @@ public class NotificationTemplates {
                 """
                 .formatted(status, formattedCreatedAt, baseUrl, resource, baseUrl, baseUrl);
     };
+
+    public static String TicketCreate(LocalDateTime createdAt, String resource, String ticketID) {
+        String formattedCreatedAt = formatDateTime(createdAt);
+
+        return """
+                You have successfully created a new `Incident Ticket`. Our team will begin processing your request shortly; please await further notification.
+
+                ---
+                ##### Ticket Details:
+                * **Submitted On:** %s
+                * **Resource:** [View Resource](%s/resources/%s)
+                * **Ticket ID:** [View Specific Ticket](%s/tickets/myticket/%s)
+
+                ---
+                [View All My Tickets](%s/tickets)
+                """
+                .formatted(formattedCreatedAt, baseUrl, resource, baseUrl, ticketID, baseUrl);
+    }
+
+
+    public static String TicketStatusUpdate(String status, String resource, String ticketID, String note) {
+
+        return """
+                ### Your ticket status has been updated to: `%s`.
+                
+                ---
+                **Update Note:**
+                > %s
+
+                #### Ticket Details:
+                * **Resource:** [View Resource](%s/resources/%s)
+                * **Ticket ID:** [View Specific Ticket](%s/tickets/myticket/%s)
+                
+                ---
+                [View All My Tickets](%s/tickets)
+                """
+                .formatted(status, note, baseUrl, resource, baseUrl, ticketID, baseUrl);
+    }
 
 }

--- a/backend/src/main/java/com/smartcampus/backend/service/TicketService.java
+++ b/backend/src/main/java/com/smartcampus/backend/service/TicketService.java
@@ -1,6 +1,7 @@
 package com.smartcampus.backend.service;
 
 import com.smartcampus.backend.dto.*;
+import com.smartcampus.backend.model.Notification;
 import com.smartcampus.backend.model.Ticket;
 import com.smartcampus.backend.model.TicketAttachment;
 import com.smartcampus.backend.model.TicketComment;
@@ -18,8 +19,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * Service layer for Ticket operations (Module C).
- *
  * Handles all business logic:
  * - Creating tickets with attachment linking
  * - Updating ticket status / assigning technicians
@@ -45,6 +44,9 @@ public class TicketService {
 
     @Autowired
     private MinioService minioService;
+
+    @Autowired
+    private NotificationService notificationService;
 
     private static final DateTimeFormatter ID_FORMATTER =
             DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
@@ -95,7 +97,21 @@ public class TicketService {
                 request.getContactPhone(),
                 userId
         );
-        ticketRepository.save(ticket);
+        Ticket newTicket = ticketRepository.save(ticket);
+
+        // for notification:by pasan
+        Notification notification = Notification.builder()
+                .userId(userId) // target user
+                .type("NEW_TICKET")
+                .title("New Incident Ticket")
+                .message(NotificationTemplates.TicketCreate(newTicket.getCreatedAt(), newTicket.getResourceId(),newTicket.getId()))
+                .referenceId(newTicket.getId())
+                .read(false)
+                .build();
+
+        notificationService.createNotification(notification);
+
+
 
         // Save attachment records (files are already in Minio)
         List<String> savedFileNames = new ArrayList<>();
@@ -110,7 +126,7 @@ public class TicketService {
         return convertToTicketResponse(ticket, savedFileNames, Collections.emptyList());
     }
 
-    // ── READ (single) ─────────────────────────────────────────────────────────
+    // READ (single)
 
     /**
      * Returns full details for one ticket including attachments and comments.
@@ -126,7 +142,7 @@ public class TicketService {
         return convertToTicketResponse(ticket, fileNames, comments);
     }
 
-    // ── READ (list) ───────────────────────────────────────────────────────────
+    // READ (list)
 
     /**
      * Returns a paginated list of tickets with optional filters.
@@ -176,7 +192,7 @@ public class TicketService {
         return new ListTicketsResponse(items, total, validPage, totalPages);
     }
 
-    // ── UPDATE (ticket) ───────────────────────────────────────────────────────
+    //  UPDATE (ticket) 
 
     /**
      * Partially updates a ticket's status, assigned technician, or resolution notes.
@@ -218,7 +234,21 @@ public class TicketService {
         }
 
         ticket.setUpdatedAt(LocalDateTime.now());
-        ticketRepository.save(ticket);
+        Ticket ticketStatus = ticketRepository.save(ticket);
+
+
+        // for notification:by pasan
+        Notification notification = Notification.builder()
+                .userId(ticketStatus.getCreatedBy()) // target user
+                .type("TICKET_STATUS_UPDATE")
+                .title("Ticket Status Update")
+                .message(NotificationTemplates.TicketStatusUpdate(ticketStatus.getStatus(), ticketStatus.getResourceId(),ticketStatus.getId(),ticketStatus.getResolutionNotes()))
+                .referenceId(ticketStatus.getId())
+                .read(false)
+                .build();
+
+        notificationService.createNotification(notification);
+
 
         List<String> fileNames = getAttachmentFileNames(ticketId);
         List<TicketComment> comments = commentRepository.findByTicketIdOrderByCreatedAtAsc(ticketId);
@@ -287,6 +317,8 @@ public class TicketService {
         );
         commentRepository.save(comment);
 
+
+
         return convertToCommentResponse(comment);
     }
 
@@ -329,7 +361,7 @@ public class TicketService {
         return convertToCommentResponse(comment);
     }
 
-    // ── COMMENTS: DELETE ──────────────────────────────────────────────────────
+    // COMMENTS: DELETE 
 
     /**
      * Deletes a comment.
@@ -357,7 +389,7 @@ public class TicketService {
         commentRepository.delete(comment);
     }
 
-    // ── COMMENTS: LIST ────────────────────────────────────────────────────────
+    // COMMENTS: LIST
 
     /**
      * Returns all comments for a ticket, ordered oldest-first.

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=backend
 spring.devtools.restart.enabled=false
 
 # Database Connection
-spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:sqlserver://database:1433;databaseName=smart_campus_v1;encrypt=true;trustServerCertificate=true}
+spring.datasource.url=${SPRING_DATASOURCE_URL:'jdbc:sqlserver://database:1433;databaseName=smart_campus_v1;encrypt=true;trustServerCertificate=true'}
 # spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:sqlserver://database:1433;databaseName=master;encrypt=true;trustServerCertificate=true}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME:sa}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:SuperSecretPassw0rd!}

--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "js/ts.tsdk.path": "node_modules/typescript/lib"
+}

--- a/frontend/app/admin/users/manageUsers/page.tsx
+++ b/frontend/app/admin/users/manageUsers/page.tsx
@@ -1,8 +1,10 @@
 import { ManageUsers } from '@/components/custom/ManageUsers'
+import { auth0 } from '@/lib/auth0';
 
-const page = () => {
+const page = async () => {
+    const { token } = await auth0.getAccessToken();
   return (
-    <div className='min-h-screen'><ManageUsers/></div>
+    <div><ManageUsers token={token}/></div>
   )
 }
 

--- a/frontend/app/api/auth0/management/users/[id]/route.ts
+++ b/frontend/app/api/auth0/management/users/[id]/route.ts
@@ -44,53 +44,49 @@ export async function GET(
         return NextResponse.json({ status: 'error', message }, { status: 500 });
     }
 }
-
-
-
 export async function DELETE(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+    _request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
 ) {
-  try {
-    const session = await auth0.getSession();
-    if (!session?.user) {
-      return NextResponse.json(
-        { status: 'error', message: 'Not authenticated' },
-        { status: 401 }
-      );
+    try {
+        const session = await auth0.getSession();
+        if (!session?.user) {
+            return NextResponse.json(
+                { status: 'error', message: 'Not authenticated' },
+                { status: 401 }
+            );
+        }
+
+        const { token } = await auth0.getAccessToken();
+        const { id } = await params;
+        const Api_Url = getBaseUrl();
+
+        const backendRes = await fetch(
+            `${Api_Url}/api/auth0/management/users/${encodeURIComponent(id)}`,
+            {
+                method: 'DELETE',
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                },
+                cache: 'no-store',
+            }
+        );
+
+        if (backendRes.status === 204) {
+            return new NextResponse(null, { status: 204 });
+        }
+
+        const data = await backendRes.text();
+
+        return new NextResponse(data, {
+            status: backendRes.status,
+            headers: {
+                'Content-Type': backendRes.headers.get('content-type') || 'application/json',
+            },
+        });
+    } catch (error: unknown) {
+        console.error('Delete Error:', error);
+        const message = error instanceof Error ? error.message : 'Internal Server Error';
+        return NextResponse.json({ status: 'error', message }, { status: 500 });
     }
-
-    const { token } = await auth0.getAccessToken();
-    const { id } = await params;
-    const Api_Url = getBaseUrl();
-
-    const backendRes = await fetch(
-      `${Api_Url}/api/auth0/management/users/${encodeURIComponent(id)}`,
-      {
-        method: 'DELETE',
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-        cache: 'no-store',
-      }
-    );
-
-    if (backendRes.status === 204) {
-      return new NextResponse(null, { status: 204 });
-    }
-
-    const data = await backendRes.text();
-
-    return new NextResponse(data, {
-      status: backendRes.status,
-      headers: {
-        'Content-Type': backendRes.headers.get('content-type') || 'application/json',
-      },
-    });
-
-  } catch (error: unknown) {
-    console.error("Delete Error:", error);
-    const message = error instanceof Error ? error.message : 'Internal Server Error';
-    return NextResponse.json({ status: 'error', message }, { status: 500 });
-  }
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,16 +1,13 @@
 import { Geist_Mono, Inter } from "next/font/google"
 
-import { NavigationBar } from "@/components/custom/NavigationBar"
+import { AIAccessBtn } from "@/components/custom/AIAccessBtn"
+import FooterSection from "@/components/custom/FooterSection"
+import NavBarNew from "@/components/custom/NavBarNew"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Toaster } from "@/components/ui/sonner"
 import { AuthProvider } from "@/lib/auth-context"
-import { auth0 } from "@/lib/auth0"
 import { cn } from "@/lib/utils"
-import { redirect } from "next/navigation"
 import "./globals.css"
-import NavBarNew from "@/components/custom/NavBarNew"
-import FooterSection from "@/components/custom/FooterSection"
-import { AIAccessBtn } from "@/components/custom/AIAccessBtn"
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-sans" })
 
@@ -24,26 +21,7 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  const session = await auth0.getSession()
-  if (!session?.user) {
-    redirect("/auth/login?returnTo=/")
-  }
 
-  try {
-    await auth0.getAccessToken()
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : ""
-    const requiresReauth =
-      errorMessage.includes("AccessTokenError") ||
-      (errorMessage.includes("expired") &&
-        errorMessage.includes("refresh token"))
-
-    if (requiresReauth) {
-      redirect("/auth/login?returnTo=/")
-    }
-
-    throw error
-  }
 
   return (
     <html

--- a/frontend/app/notifications/[id]/page.tsx
+++ b/frontend/app/notifications/[id]/page.tsx
@@ -35,7 +35,7 @@ interface ApiResponseProps {
 }
 
 const page = () => {
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
   const params = useParams()
   const id = params.id as string
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,74 +1,51 @@
-import { HomeAdminPageAccessBtn } from '@/components/custom/HomeAdminPageAccessBtn';
-import { HomeImageSlider } from '@/components/custom/HomeImageSlider';
-import { SERVER_API_URL } from '@/lib/api-client';
-import { auth0 } from '@/lib/auth0';
-import { redirect } from 'next/navigation';
+import { HomeAdminPageAccessBtn } from "@/components/custom/HomeAdminPageAccessBtn"
+import { HomeImageSlider } from "@/components/custom/HomeImageSlider"
+import { SERVER_API_URL } from "@/lib/api-client"
+import { auth0 } from "@/lib/auth0"
+import { redirect } from "next/navigation"
 
 type BackendProfileResponse = {
-  status: 'success';
+  status: "success"
   data: {
-    id: number | string;
-    name: string;
-    email: string;
-    role: string;
-  };
-};
+    id: number | string
+    name: string
+    email: string
+    role: string
+  }
+}
 
 const page = async () => {
-  const session = await auth0.getSession();
+  const session = await auth0.getSession()
   if (!session?.user) {
-    redirect('/auth/login')
+    redirect("/auth/login")
   }
 
-  let profile: BackendProfileResponse['data'] | null = null;
+  let profile: BackendProfileResponse["data"] | null = null
 
   try {
-    const { token } = await auth0.getAccessToken();
-    console.log(token)
+    const { token } = await auth0.getAccessToken()
+    console.log("getAccessToken " + token)
+    // console.log( "getAccessToken " + expiresAt )
 
     // Keep backend user record in sync with Auth0 identity.
     await fetch(`${SERVER_API_URL}/api/auth/register`, {
-      method: 'POST',
+      method: "POST",
       headers: {
         Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
-      cache: 'no-store',
-    });
-
-    const profileRes = await fetch(`${SERVER_API_URL}/api/auth/me`, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-      cache: 'no-store',
-    });
-
-    if (profileRes.ok) {
-      const body: BackendProfileResponse = await profileRes.json();
-      profile = body.data;
-    }
+      cache: "no-store",
+    })
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : '';
+    const errorMessage = error instanceof Error ? error.message : ""
 
-    const requiresReauth =
-      errorMessage.includes('AccessTokenError') ||
-      (errorMessage.includes('expired') && errorMessage.includes('refresh token'));
-
-    if (requiresReauth) {
-      redirect('/auth/login?returnTo=/');
-    }
-
-    console.error('Failed to load backend profile: ', error)
+    console.error("Failed to load backend profile: ", error)
   }
-
-
-  
 
   return (
     <main>
-      <HomeAdminPageAccessBtn/>
-      <HomeImageSlider/>
+      <HomeAdminPageAccessBtn />
+      <HomeImageSlider />
     </main>
 
     // <div>

--- a/frontend/app/unauthorized/page.tsx
+++ b/frontend/app/unauthorized/page.tsx
@@ -1,40 +1,34 @@
+"use client"
+import { FolderXIcon, Home } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+    Empty,
+    EmptyContent,
+    EmptyDescription,
+    EmptyHeader,
+    EmptyMedia,
+    EmptyTitle,
+} from "@/components/ui/empty"
+import { useRouter } from "next/navigation"
 export default function UnauthorizedPage() {
+  const router = useRouter();
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-red-50 to-orange-50 px-4">
-      <div className="max-w-md w-full text-center">
-        <div className="mb-8">
-          <h1 className="text-6xl font-bold text-red-600 mb-2">403</h1>
-          <h2 className="text-2xl font-semibold text-gray-900">Access Denied</h2>
+    <div className="flex min-h-[70vh] items-center justify-center p-4">
+            <Empty>
+                <EmptyHeader>
+                    <EmptyMedia variant="icon" className="text-destructive">
+                        <FolderXIcon />
+                    </EmptyMedia>
+                    <EmptyTitle>Access denied!</EmptyTitle>
+                    <EmptyDescription>
+                        You don't have permission to view this page. Contact your administrator if you think this is a mistake.
+                    </EmptyDescription>
+                </EmptyHeader>
+                <EmptyContent className="flex-row justify-center gap-2">
+                    <Button onClick={() => router.push(`/`)}><Home /> Go Back Home</Button>
+                </EmptyContent>
+            </Empty>
         </div>
-
-        <div className="bg-white rounded-lg border border-red-200 p-6 mb-8 shadow-sm">
-          <p className="text-gray-700 mb-4">
-            You don't have permission to access this page. Your current access level may not be sufficient for this resource.
-          </p>
-          <p className="text-sm text-gray-600">
-            If you believe you should have access, please contact your administrator.
-          </p>
-        </div>
-
-        <div className="flex gap-3">
-          <a
-            href="/dashboard"
-            className="flex-1 px-4 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition font-medium"
-          >
-            Go to Dashboard
-          </a>
-          <a
-            href="/user/profile"
-            className="flex-1 px-4 py-3 bg-gray-200 text-gray-900 rounded-lg hover:bg-gray-300 transition font-medium"
-          >
-            View Profile
-          </a>
-        </div>
-
-        <p className="text-xs text-gray-500 mt-6">
-          If you continue to see this error, try logging out and logging back in.
-        </p>
-      </div>
-    </div>
-  );
+  )
 }

--- a/frontend/components/custom/ManageUserAddNew.tsx
+++ b/frontend/components/custom/ManageUserAddNew.tsx
@@ -1,0 +1,43 @@
+import { Button } from "@/components/ui/button"
+import {
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Field, FieldGroup } from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+export const ManageUserAddNew = () => {
+  return (
+    <form>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Edit profile</DialogTitle>
+          <DialogDescription>
+            Make changes to your profile here. Click save when you&apos;re done.
+          </DialogDescription>
+        </DialogHeader>
+        <FieldGroup>
+          <Field>
+            <Label htmlFor="name-1">Name</Label>
+            <Input id="name-1" name="name" defaultValue="Pedro Duarte" />
+          </Field>
+          <Field>
+            <Label htmlFor="username-1">Username</Label>
+            <Input id="username-1" name="username" defaultValue="@peduarte" />
+          </Field>
+        </FieldGroup>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <Button type="submit">Save changes</Button>
+        </DialogFooter>
+      </DialogContent>
+    </form>
+  )
+}

--- a/frontend/components/custom/ManageUserDelete.tsx
+++ b/frontend/components/custom/ManageUserDelete.tsx
@@ -8,29 +8,44 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
+import { getBaseUrl } from "@/lib/api-client"
+import { Auth0ErrorProp } from "@/lib/Auth0ErrorPrope"
 import { useState } from "react"
 import { toast } from "sonner"
 
-export const ManageUserDelete = ({ deleteUrl }: { deleteUrl: string }) => {
+export const ManageUserDelete = ({
+  deleteUrl,
+  token,
+}: {
+  deleteUrl: string
+  token: string
+}) => {
   const [loading, setLoading] = useState<boolean>(false)
+  const [error, setError] = useState<Auth0ErrorProp | null>(null)
+  const Api_Url = getBaseUrl()
   const handleDelete = async () => {
     setLoading(true)
+    console.log("Api_Url: "+Api_Url)
+    console.log("token: "+token)
 
     try {
-      const response = await fetch(`${deleteUrl}`, {
+      const response = await fetch(`${Api_Url}${deleteUrl}`, {
         method: "DELETE",
         headers: {
           "Content-Type": "application/json",
+          "Authorization": `Bearer ${token}`,
         },
       })
 
+      console.log("respoce: "+response)
       if (!response.ok) {
-        throw new Error("Failed to delete the item.")
+        const errorData: Auth0ErrorProp = await response.json()
+        setError(errorData)
+        throw new Error(errorData.message || "Failed to delete the item.")
       }
-
       toast.success("User removed successfully")
     } catch (err) {
-      toast.error("Something went wrong.")
+      toast.error(error?.message || "An error occurred")
       console.log(err instanceof Error ? err.message : "Something went wrong")
     } finally {
       setLoading(false)
@@ -48,7 +63,9 @@ export const ManageUserDelete = ({ deleteUrl }: { deleteUrl: string }) => {
       </AlertDialogHeader>
       <AlertDialogFooter>
         <AlertDialogCancel>Cancel</AlertDialogCancel>
-        <AlertDialogAction onClick={handleDelete}>Continue</AlertDialogAction>
+        <AlertDialogAction onClick={handleDelete} variant={"destructive"}>
+          Delete
+        </AlertDialogAction>
       </AlertDialogFooter>
     </AlertDialogContent>
   )

--- a/frontend/components/custom/ManageUsers.tsx
+++ b/frontend/components/custom/ManageUsers.tsx
@@ -136,7 +136,7 @@ interface ApiUserRoleResponseProp {
 // @RequestParam(required = false) String sort,
 // @RequestParam(required = false) String search)
 
-function ActionsCell({ row }: { row: Row<userProp> }) {
+function ActionsCell({ row,token }: { row: Row<userProp>,token:string }) {
   const { copyToClipboard } = useCopyToClipboard()
   const handleCopyId = () => {
     copyToClipboard(row.original.userId)
@@ -171,13 +171,13 @@ function ActionsCell({ row }: { row: Row<userProp> }) {
             <IconTrashX />
           </Button>
         </AlertDialogTrigger>
-        <ManageUserDelete deleteUrl={row.original._links.delete_user.href}/>
+        <ManageUserDelete deleteUrl={row.original._links.delete_user.href} token={token} />
       </AlertDialog>
     </ButtonGroup>
   )
 }
 
-export function ManageUsers() {
+export function ManageUsers({token}:{token:string}) {
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: 10,
@@ -269,6 +269,32 @@ export function ManageUsers() {
       //   enableResizing: false,
       // },
       {
+        accessorKey: "userId",
+        id: "userId",
+        header: ({ column }) => (
+          <DataGridColumnHeader
+            title="User ID"
+            visibility={true}
+            column={column}
+          />
+        ),
+        cell: ({ row }) => {
+          return (
+            <div className="flex items-center gap-1.5">
+              <span> {row.original.userId}</span>
+            </div>
+          )
+        },
+        size: 100,
+        meta: {
+          headerClassName: "",
+          cellClassName: "text-start",
+        },
+        enableSorting: true,
+        enableHiding: true,
+        enableResizing: true,
+      },
+      {
         accessorKey: "user",
         id: "user",
         header: ({ column }) => (
@@ -331,7 +357,7 @@ export function ManageUsers() {
             </div>
           )
         },
-        size: 150,
+        size: 125,
         meta: {
           headerClassName: "",
           cellClassName: "text-start",
@@ -363,7 +389,7 @@ export function ManageUsers() {
             </div>
           )
         },
-        size: 150,
+        size: 125,
         meta: {
           headerClassName: "",
           cellClassName: "text-start",
@@ -395,7 +421,7 @@ export function ManageUsers() {
             </div>
           )
         },
-        size: 150,
+        size: 125,
         meta: {
           headerClassName: "",
           cellClassName: "text-start",
@@ -451,7 +477,7 @@ export function ManageUsers() {
         cell: ({ row }) => {
           return (
             <div className="flex items-center gap-1.5">
-              <div className="font-medium text-foreground">
+              <div className="text-foreground">
                 {formatDateTime(row.original.createdAt)}
               </div>
             </div>
@@ -481,7 +507,7 @@ export function ManageUsers() {
         cell: ({ row }) => {
           return (
             <div className="flex items-center gap-1.5">
-              <div className="font-medium text-foreground">
+              <div className="text-foreground">
                 {formatDateTime(row.original.updatedAt)}
               </div>
             </div>
@@ -511,7 +537,7 @@ export function ManageUsers() {
         cell: ({ row }) => {
           return (
             <div className="flex items-center gap-1.5">
-              <div className="font-medium text-foreground">
+              <div className="text-foreground">
                 {formatDateTime(row.original.lastLogin)}
               </div>
             </div>
@@ -541,9 +567,7 @@ export function ManageUsers() {
         cell: ({ row }) => {
           return (
             <div className="flex items-center gap-1.5">
-              <div className="font-medium text-foreground">
-                {row.original.lastIp}
-              </div>
+              <div className="text-foreground">{row.original.lastIp}</div>
             </div>
           )
         },
@@ -569,9 +593,7 @@ export function ManageUsers() {
         ),
         cell: ({ row }) => {
           return (
-            <div className="font-medium text-foreground">
-              {row.original.loginsCount}
-            </div>
+            <div className="text-foreground">{row.original.loginsCount}</div>
           )
         },
         size: 150,
@@ -583,8 +605,8 @@ export function ManageUsers() {
       {
         id: "actions",
         header: "",
-        cell: ({ row }) => <ActionsCell row={row} />,
-        size: 150,
+        cell: ({ row }) => <ActionsCell row={row} token={token} />,
+   
         enableSorting: false,
         enableHiding: false,
         enableResizing: false,
@@ -672,10 +694,15 @@ export function ManageUsers() {
             </div>
           </div>
           <CardAction>
-            <Button>
-              <UserPlusIcon />
-              Add new
-            </Button>
+            <Dialog>
+              <DialogTrigger asChild>
+                <Button variant="outline" className="cursor-pointer">
+                  <UserPlusIcon />
+                  Add new
+                </Button>
+              </DialogTrigger>
+              <ManageUserEditProfile />
+            </Dialog>
           </CardAction>
         </CardHeader>
         <CardContent className="border-y px-0">

--- a/frontend/components/custom/MyBookings.tsx
+++ b/frontend/components/custom/MyBookings.tsx
@@ -108,28 +108,37 @@ export const MyBookings = () => {
 
   // Inside export const MyBookings = () => { ...
 
+  const fetchBookings = async () => {
+    try {
+      const response = await fetch("/api/bookings/me", {
+        method: "GET",
+        headers: { "Content-Type": "application/json" },
+      })
+      const result: ApiResponseProps = await response.json()
+
+      if (result.status === "success") {
+        setBookings(result.data.items)
+        setFiltered(result.data.items)
+      }
+    } catch (error) {
+      toast.warning("Something went wrong!")
+      console.error("Failed to fetch data:", error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
   const handleCancel = async (bookingId: string) => {
     try {
-      const response = await fetch(`/api/bookings/${bookingId}/status`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          status: "CANCELLED",
-          reason: "User cancelled request",
-        }),
+      const response = await fetch(`/api/bookings/${bookingId}`, {
+        method: "DELETE",
       })
 
       if (response.ok) {
-        toast.success("Booking cancelled")
-
-        // Real-time state update prevents unnecessary page reloads
-        setBookings((prev) =>
-          prev.map((b) =>
-            b.id === bookingId ? { ...b, status: "CANCELLED" } : b
-          )
-        )
+        toast.success("Booking Deleted")
+        await fetchBookings()
       } else {
-        toast.error("Unable to cancel booking at this time.")
+        toast.error("Unable to delete booking at this time.")
       }
     } catch (error) {
       toast.error("Connection error. Check your network.")
@@ -137,25 +146,7 @@ export const MyBookings = () => {
   }
 
   useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const response = await fetch("/api/bookings/me", {
-          method: "GET",
-          headers: { "Content-Type": "application/json" },
-        })
-        const result: ApiResponseProps = await response.json()
-        if (result.status === "success") {
-          setBookings(result.data.items)
-          setFiltered(result.data.items)
-        }
-      } catch (error) {
-        toast.warning("Something went wrong!")
-        console.error("Failed to fetch data:", error)
-      } finally {
-        setLoading(false)
-      }
-    }
-    fetchData()
+    fetchBookings()
   }, [])
 
   // Filter whenever search or statusFilter changes

--- a/frontend/components/custom/NotificationIcon.tsx
+++ b/frontend/components/custom/NotificationIcon.tsx
@@ -40,8 +40,8 @@ export const NotificationIcon = () => {
           </div>
           <DropdownMenuGroup>
             {!loading ? (
-              notifications.map((notification) => (
-                <DropdownMenuItem>
+              notifications.map((notification,index) => (
+                <DropdownMenuItem key={index}>
                   <NotificationBox
                     key={notification.id}
                     id={notification.id}

--- a/frontend/components/custom/ViewResourcesTable.tsx
+++ b/frontend/components/custom/ViewResourcesTable.tsx
@@ -146,7 +146,7 @@ export const ViewResourcesTable = () => {
             }
         } catch (error) {
             console.error("Error deleting resource:", error)
-            toast.error("Failed to delete resource")
+            toast.error("You can not delete this Resource.")
         } finally {
             setIsDeleting(false)
         }

--- a/frontend/lib/Auth0ErrorPrope.ts
+++ b/frontend/lib/Auth0ErrorPrope.ts
@@ -1,0 +1,5 @@
+export interface Auth0ErrorProp {
+    error: string|null
+    message: string|null
+    statusCode: number|null
+}

--- a/frontend/lib/auth0.ts
+++ b/frontend/lib/auth0.ts
@@ -5,11 +5,27 @@ export const auth0 = new Auth0Client({
   clientId: process.env.AUTH0_CLIENT_ID,
   clientSecret: process.env.AUTH0_CLIENT_SECRET,
   secret: process.env.AUTH0_SECRET,
-  // v4 expects APP_BASE_URL; this fallback supports existing AUTH0_BASE_URL setups.
   appBaseUrl: process.env.APP_BASE_URL || process.env.AUTH0_BASE_URL,
   authorizationParameters: {
-    // CRITICAL: This guarantees the token is valid for your Spring Boot backend
     audience: process.env.AUTH0_AUDIENCE,
     scope: 'openid profile email'
+  },
+
+  async beforeSessionSaved(session) {
+    const namespace = 'https://smartcampus.api';
+
+    const payload = JSON.parse(
+      Buffer.from(session.tokenSet.idToken!.split('.')[1], 'base64').toString()
+    );
+
+    return {
+      ...session,
+      user: {
+        ...session.user,
+        [`${namespace}/roles`]: payload[`${namespace}/roles`],
+        [`${namespace}/email`]: payload[`${namespace}/email`],
+        [`${namespace}/name`]:  payload[`${namespace}/name`],
+      }
+    };
   }
 });

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -1,21 +1,10 @@
 import { auth0 } from "@/lib/auth0";
 import { NextResponse, type NextRequest } from "next/server";
 
-const PUBLIC_PATHS = [
-  "/unauthorized",
-];
-
-// Paths that Auth0 itself handles — never redirect these
-const AUTH0_PATHS = [
-  "/auth/login",
-  "/auth/logout", 
-  "/auth/callback",
-  "/auth/profile",
-];
+const PUBLIC_PATHS = ["/unauthorized"];
 
 function isPublicPath(pathname: string): boolean {
-  // Always let Auth0's own routes through
-  if (AUTH0_PATHS.some(p => pathname === p || pathname.startsWith(p))) return true;
+  if (pathname.startsWith("/auth")) return true;
   if (pathname.startsWith("/api")) return true;
   return PUBLIC_PATHS.some(
     (path) => pathname === path || pathname.startsWith(`${path}/`)
@@ -25,34 +14,33 @@ function isPublicPath(pathname: string): boolean {
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // Let Auth0 handle its own routes without any interference
   if (isPublicPath(pathname)) {
     return auth0.middleware(request);
   }
 
-  // For protected routes: run Auth0 middleware first, then check session
-  const authResponse = await auth0.middleware(request);
+  const session = await auth0.getSession(request);
 
-  // Use Auth0's getSession() instead of manually checking cookies
-  // This correctly handles chunked, prefixed, and encrypted session cookies
-  try {
-    const session = await auth0.getSession(request);
-
-    if (!session?.user) {
-      const loginUrl = new URL("/auth/login", request.url);
-      loginUrl.searchParams.set(
-        "returnTo",
-        `${pathname}${request.nextUrl.search}`
-      );
-      return NextResponse.redirect(loginUrl);
-    }
-  } catch {
-    // If session check throws, redirect to login
+  if (!session || !session.user) {
     const loginUrl = new URL("/auth/login", request.url);
+    loginUrl.searchParams.set("returnTo", `${pathname}${request.nextUrl.search}`);
     return NextResponse.redirect(loginUrl);
   }
 
-  return authResponse;
+  const ADMIN_ONLY_PATHS = ["/admin", "/component"];
+  const namespace = "https://smartcampus.api";
+  const { user } = session;
+
+  // Safe fallback to empty array if roles is missing
+  const roles = (user[`${namespace}/roles`] as string[]) ?? [];
+  console.log("roles:", roles);
+
+  const isAdminPath = ADMIN_ONLY_PATHS.some((path) => pathname.startsWith(path));
+
+  if (isAdminPath && !roles.includes("ADMIN")) {
+    return NextResponse.redirect(new URL("/unauthorized", request.url));
+  }
+
+  return auth0.middleware(request);
 }
 
 export const config = {


### PR DESCRIPTION
Add spring-boot-starter-webflux and a WebClient bean, then refactor Auth0ManagementController to use reactive WebClient (returning Mono<ResponseEntity<String>>) for user and role endpoints and proxy-style forwards. Improve HTTP error handling: Auth0ManagementApiService now maps non-2xx responses to HttpClientErrorException/HttpServerErrorException and the controller builds a parsed error response map. Add new notification templates and wire NotificationService into TicketService. Also include assorted formatting/comment cleanups across controllers/repositories/services, update application properties, and add frontend pieces for user management and Auth0 error handling (new components, pages and proxy changes).